### PR TITLE
Introduce a custom error code

### DIFF
--- a/mypy_nonfloat_decimal/mypy_nonfloat_decimal.py
+++ b/mypy_nonfloat_decimal/mypy_nonfloat_decimal.py
@@ -1,9 +1,19 @@
 """Mypy plugin: non-float check for Decimal."""
+
 from decimal import Decimal
 from typing import Callable, Optional
 
+from mypy.errorcodes import MISC, ErrorCode
 from mypy.plugin import FunctionContext, Plugin
 from mypy.types import AnyType, Instance, LiteralType, TupleType, Type, UnionType
+
+VALID_DECIMAL_ARG = ErrorCode(
+    "valid-decimal-arg",
+    "Check valid argument provided when constructing a Decimal, e.g. non-float",
+    "General",
+    # Make a subcode of `misc` for backward compatibility.
+    sub_code_of=MISC,
+)
 
 
 class InvalidType(ValueError):
@@ -53,6 +63,7 @@ def analyze_decimal_call(ctx: FunctionContext) -> Type:
                     param, str(e)
                 ),
                 ctx.context,
+                code=VALID_DECIMAL_ARG,
             )
 
     return ctx.default_return_type

--- a/tests/test_nonfloat_decimal.yml
+++ b/tests/test_nonfloat_decimal.yml
@@ -21,9 +21,9 @@
     Decimal(Literal["1.02"])
 
   out: |
-    main:10: error: Invalid type passed to Decimal (expected "Union[int, str, Decimal]"), got builtins.float instead (offender: float)
-    main:11: error: Invalid type passed to Decimal (expected "Union[int, str, Decimal]"), got builtins.object instead (offender: object)
-    main:11: error: Argument 1 to "Decimal" has incompatible type "object"; expected "Union[Decimal, float, str, Tuple[int, Sequence[int], int]]"
+    main:10: error: Invalid type passed to Decimal (expected "Union[int, str, Decimal]"), got builtins.float instead (offender: float)  [valid-decimal-arg]
+    main:11: error: Invalid type passed to Decimal (expected "Union[int, str, Decimal]"), got builtins.object instead (offender: object)  [valid-decimal-arg]
+    main:11: error: Argument 1 to "Decimal" has incompatible type "object"; expected "Decimal | float | str | tuple[int, Sequence[int], int]"  [arg-type]
 
 - case: test_any_union_ok
   main: |
@@ -42,7 +42,7 @@
     c = 1  # type: Union[Decimal, float, str, int]
     Decimal(c)
   out: |
-    main:5: error: Invalid type passed to Decimal (expected "Union[int, str, Decimal]"), got Union[_decimal.Decimal, builtins.float, builtins.str, builtins.int] instead (offender: float)
+    main:5: error: Invalid type passed to Decimal (expected "Union[int, str, Decimal]"), got Union[decimal.Decimal, builtins.float, builtins.str, builtins.int] instead (offender: float)  [valid-decimal-arg]
 
 - case: test_complex_nested_tuple_union_err
   main: |
@@ -52,4 +52,4 @@
     d = 1  # type: Union[Decimal, float, str, Tuple[int, Sequence[int], int]]
     Decimal(d)
   out: |
-    main:5: error: Invalid type passed to Decimal (expected "Union[int, str, Decimal]"), got Union[_decimal.Decimal, builtins.float, builtins.str, Tuple[builtins.int, typing.Sequence[builtins.int], builtins.int]] instead (offender: float)
+    main:5: error: Invalid type passed to Decimal (expected "Union[int, str, Decimal]"), got Union[decimal.Decimal, builtins.float, builtins.str, tuple[builtins.int, typing.Sequence[builtins.int], builtins.int]] instead (offender: float)  [valid-decimal-arg]


### PR DESCRIPTION
Instead of falling back to the default `misc` error code, introduce `valid-decimal-arg` as a custom error code. Keep it as a sub-code of `misc` for backward compatibility.

A custom error code makes it easier to determine the cause of an error and filter as required.